### PR TITLE
Redirect set up so root goes to installation page, using a gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group :jekyll_plugins do
    gem 'jekyll-gist'
    gem 'jekyll-livereload'
    gem 'jekyll-avatar'
+   gem 'jekyll-redirect-from'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,8 @@ GEM
       em-websocket (~> 0.5)
       jekyll (~> 3.0)
     jekyll-paginate (1.1.0)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
     jekyll-seo-tag (2.6.1)
@@ -78,11 +80,12 @@ DEPENDENCIES
   jekyll-gist
   jekyll-livereload
   jekyll-paginate (~> 1.1)
+  jekyll-redirect-from
   jekyll-seo-tag
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.7.0p0
+   ruby 2.6.3p62
 
 BUNDLED WITH
    2.1.4

--- a/_config.yml
+++ b/_config.yml
@@ -125,6 +125,9 @@ paginate_path:      "/blog/:num/"
 # Path to post content assets directory i.e post images, pdfs etc
 uploads:            /uploads/
 
+plugins:
+  - jekyll-redirect-from
+
 # Build settings
 markdown:           kramdown
 highlighter:        rouge

--- a/_data/navigation_docs.yml
+++ b/_data/navigation_docs.yml
@@ -1,6 +1,5 @@
 - title: Getting Started
   docs:
-  - installation
   - setup
   - admin
   - teammember

--- a/_data/navigation_header.yml
+++ b/_data/navigation_header.yml
@@ -1,11 +1,8 @@
 # Navbar left menu navigation links
 
 left:
-  - title: Home
-    url: /
-
   - title: Docs
-    url: /docs/installation/
+    url: /
 
 
   # - title: Changelogs

--- a/_data/navigation_header.yml
+++ b/_data/navigation_header.yml
@@ -24,7 +24,7 @@ right:
   #   button: primary-outline
 
   - title: Report an Issue
-    url: https://github.com/GitLiveApp/documentation/issues/new
+    url: https://github.com/GitLiveApp/GitLive/issues/new
     button: success
 
   # - title: Changelog

--- a/_docs/installation.md
+++ b/_docs/installation.md
@@ -1,11 +1,15 @@
 ---
-title: GitLive installation
+title: GitLive Installation
 styleid: main-nav
 subtitle: This section will guide you in installing GitLive on your IDE.
 author: friedrich
 subsection: [VS Code, JetBrains, Android Studio]
 step: first
 tags: [setup, installation, plugin, extension]
+permalink: /
+redirect_from:
+  - /docs/installation
 ---
+
 
 empty

--- a/_docs/support.md
+++ b/_docs/support.md
@@ -6,4 +6,4 @@ author: friedrich
 
 ---
 
-If you would like to improve the documentation for GitLive or report a bug that you have encountered, report an issue on Github following the guidelines indicated in our [README](https://github.com/GitLiveApp/documentation).
+If you would like to improve the documentation for GitLive or report a bug that you have encountered, report an issue on Github following the guidelines indicated in our [README](https://github.com/GitLiveApp/GitLive).

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -8,14 +8,17 @@ layout: default
             <div class="sidebar-fixed-width uk-visible@m">
                 <div class="sidebar-docs uk-position-fixed uk-margin-top">
                     {% for section in site.data.navigation_docs %}
-                    <h5>{{ section.title }}</h5>
-                    <ul class="uk-nav uk-nav-default doc-nav">
-                    {% for doc in section.docs %}
-                      {% assign doc_url = doc | prepend:"/docs/" | append:"/" %}
-                      {% assign p = site.docs | where:"url", doc_url | first %}
-                      <li id="{{ p.styleid }}" class="{% if doc_url == page.url %}uk-active{% endif %}"><a href="{{ p.url }}">{{ p.title }}</a></li>
-                    {% endfor %}
-                    </ul>
+                      <h5>{{ section.title }}</h5>
+                      <ul class="uk-nav uk-nav-default doc-nav">
+                        {% if section.title == "Getting Started" %}
+                          <li class="{% if page.url == '/' %}uk-active{% endif %}"><a href="/"> GitLive Installation</a></li>
+                        {% endif %}
+                        {% for doc in section.docs %}
+                          {% assign doc_url = doc | prepend:"/docs/" | append:"/" %}
+                          {% assign p = site.docs | where:"url", doc_url | first %}
+                          <li id="{{ p.styleid }}" class="{% if doc_url == page.url %}uk-active{% endif %}"><a href="{{ p.url }}">{{ p.title }}</a></li>
+                        {% endfor %}
+                      </ul>
                     {% endfor %}
                 </div>
             </div>

--- a/_sections/account-management-android-studio.md
+++ b/_sections/account-management-android-studio.md
@@ -40,7 +40,7 @@ After confirming you want to delete the account, you will see that it has been r
 ![3 Accounts](/uploads/android-studio-3-accounts.jpeg "3 Accounts"){:class="screenshot"}
 
 
-[Suggest an Edit to this Page](https://github.com/GitLiveApp/documentation/edit/master/_sections/account-management-android-studio.md){:class="uk-button uk-button-success"}
+[Suggest an Edit to this Page](https://github.com/GitLiveApp/GitLive/edit/master/_sections/account-management-android-studio.md){:class="uk-button uk-button-success"}
 
 
 

--- a/_sections/account-management-jetbrains.md
+++ b/_sections/account-management-jetbrains.md
@@ -40,7 +40,7 @@ After confirming you want to delete the account, you will see that it has been r
 ![3 Accounts](/uploads/jetbrains-3-accounts.jpg "3 Accounts"){:class="screenshot"}
 
 
-[Suggest an Edit to this Page](https://github.com/GitLiveApp/documentation/edit/master/_sections/account-management-jetbrains.md){:class="uk-button uk-button-success"}
+[Suggest an Edit to this Page](https://github.com/GitLiveApp/GitLive/edit/master/_sections/account-management-jetbrains.md){:class="uk-button uk-button-success"}
 
 
 

--- a/_sections/account-management-vscode.md
+++ b/_sections/account-management-vscode.md
@@ -40,6 +40,6 @@ After confirming you want to delete the account, you will see that it has been r
 ![3 Accounts](/uploads/vscode-3-accounts.jpg "3 Accounts"){:class="screenshot"}
 
 
-[Suggest an Edit to this Page](https://github.com/GitLiveApp/documentation/edit/master/_sections/account-management-vscode.md){:class="uk-button uk-button-success"}
+[Suggest an Edit to this Page](https://github.com/GitLiveApp/GitLive/edit/master/_sections/account-management-vscode.md){:class="uk-button uk-button-success"}
 
 

--- a/_sections/admin-android-studio.md
+++ b/_sections/admin-android-studio.md
@@ -39,4 +39,4 @@ As an administrator, you are required to install the GitLive app on the organiza
 * You can now have your team members install the plugin and authenticate. See the [setting up as a team member section](/docs/teammember){:class="internal-link"}.
 
 
-[Suggest an Edit to this Page](https://github.com/GitLiveApp/documentation/edit/master/_sections/admin-android-studio.md){:class="uk-button uk-button-success"}
+[Suggest an Edit to this Page](https://github.com/GitLiveApp/GitLive/edit/master/_sections/admin-android-studio.md){:class="uk-button uk-button-success"}

--- a/_sections/admin-android-studio.md
+++ b/_sections/admin-android-studio.md
@@ -13,7 +13,7 @@ As an administrator, you are required to install the GitLive app on the organiza
 
 ### Step 1
 
-* Install the plugin as explained in the [installation section](/docs/installation){:class="internal-link"}
+* Install the plugin as explained in the [installation section](/){:class="internal-link"}
 * Open up a clone of the repository that you want to use GitLive with.
 
 ### Step 2

--- a/_sections/admin-jetbrains.md
+++ b/_sections/admin-jetbrains.md
@@ -13,7 +13,7 @@ As an administrator, you are required to install the GitLive app on the organiza
 
 ### Step 1
 
-* Install the plugin as explained in the [installation section](/docs/installation){:class="internal-link"}
+* Install the plugin as explained in the [installation section](/){:class="internal-link"}
 * Open up a clone of the repository that you want to use GitLive with.
 
 ### Step 2

--- a/_sections/admin-jetbrains.md
+++ b/_sections/admin-jetbrains.md
@@ -39,4 +39,4 @@ As an administrator, you are required to install the GitLive app on the organiza
 * You can now have your team members install the plugin and authenticate. See the  [setting up as a team member section](/docs/teammember){:class="internal-link"}.
 
 
-[Suggest an Edit to this Page](https://github.com/GitLiveApp/documentation/edit/master/_sections/admin-jetbrains.md){:class="uk-button uk-button-success"}
+[Suggest an Edit to this Page](https://github.com/GitLiveApp/GitLive/edit/master/_sections/admin-jetbrains.md){:class="uk-button uk-button-success"}

--- a/_sections/admin-vscode.md
+++ b/_sections/admin-vscode.md
@@ -39,4 +39,4 @@ As an administrator, you are required to install the GitLive app on the organiza
 * You can now have your team members install the plugin and authenticate. See the  [setting up as a team member section](/docs/teammember){:class="internal-link"}.
 
 
-[Suggest an Edit to this Page](https://github.com/GitLiveApp/documentation/edit/master/_sections/admin-vscode.md){:class="uk-button uk-button-success"}
+[Suggest an Edit to this Page](https://github.com/GitLiveApp/GitLive/edit/master/_sections/admin-vscode.md){:class="uk-button uk-button-success"}

--- a/_sections/admin-vscode.md
+++ b/_sections/admin-vscode.md
@@ -13,7 +13,7 @@ As an administrator, you are required to install the GitLive app on the organiza
 
 ### Step 1
 
-* Install the plugin as explained in the [installation section](/docs/installation){:class="internal-link"}.
+* Install the plugin as explained in the [installation section](/){:class="internal-link"}.
 * Open up a clone of your the repository that you want to use GitLive with.
 
 ### Step 2

--- a/_sections/installation-android-studio.md
+++ b/_sections/installation-android-studio.md
@@ -47,4 +47,4 @@ In this quick guide you will learn how to install GitLive into the Android Studi
 
 ![Confirm installation](/uploads/android-studio-installed-3.jpeg  "Confirm installation"){:class="screenshot"}
 
-[Suggest an Edit to this Page](https://github.com/GitLiveApp/documentation/edit/master/_sections/installation-android-studio.md){:class="uk-button uk-button-success"}
+[Suggest an Edit to this Page](https://github.com/GitLiveApp/GitLive/edit/master/_sections/installation-android-studio.md){:class="uk-button uk-button-success"}

--- a/_sections/installation-jetbrain.md
+++ b/_sections/installation-jetbrain.md
@@ -45,5 +45,5 @@ In this quick guide you will learn how to install GitLive into any JetBrains IDE
 
 ![Confirm installation](/uploads/jetbrains-installed-3.jpeg "Confirm installation"){:class="screenshot"}
 
-[Suggest an Edit to this Page](https://github.com/GitLiveApp/documentation/edit/master/_sections/installation-jetbrain.md){:class="uk-button uk-button-success"}
+[Suggest an Edit to this Page](https://github.com/GitLiveApp/GitLive/edit/master/_sections/installation-jetbrain.md){:class="uk-button uk-button-success"}
 

--- a/_sections/installation-vscode.md
+++ b/_sections/installation-vscode.md
@@ -33,4 +33,4 @@ You should now see the GitLive Logo on your sidebar navigation. This will appear
 
 
 
-[Suggest an Edit to this Page](https://github.com/GitLiveApp/documentation/edit/master/_sections/installation-vscode.md){:class="uk-button uk-button-success"}
+[Suggest an Edit to this Page](https://github.com/GitLiveApp/GitLive/edit/master/_sections/installation-vscode.md){:class="uk-button uk-button-success"}

--- a/_sections/pairprogramming-android-studio.md
+++ b/_sections/pairprogramming-android-studio.md
@@ -35,6 +35,6 @@ As with all GitLive features, real-time editing works interoperably between supp
 ![Pair Programming](/uploads/pairprogramming.gif "Pair Programming Example")
 
 
-[Suggest an Edit to this Page](https://github.com/GitLiveApp/documentation/edit/master/_sections/pairprogramming-android-studio.md){:class="uk-button uk-button-success"}
+[Suggest an Edit to this Page](https://github.com/GitLiveApp/GitLive/edit/master/_sections/pairprogramming-android-studio.md){:class="uk-button uk-button-success"}
 
 

--- a/_sections/pairprogramming-jetbrains.md
+++ b/_sections/pairprogramming-jetbrains.md
@@ -36,6 +36,6 @@ As with all GitLive features, real-time editing works interoperably between supp
 
 
 
-[Suggest an Edit to this Page](https://github.com/GitLiveApp/documentation/edit/master/_sections/pairprogramming-jetbrains.md){:class="uk-button uk-button-success"}
+[Suggest an Edit to this Page](https://github.com/GitLiveApp/GitLive/edit/master/_sections/pairprogramming-jetbrains.md){:class="uk-button uk-button-success"}
 
 

--- a/_sections/pairprogramming-vscode.md
+++ b/_sections/pairprogramming-vscode.md
@@ -36,5 +36,5 @@ As with all GitLive features, real-time editing works interoperably between supp
 
 
 
-[Suggest an Edit to this Page](https://github.com/GitLiveApp/documentation/edit/master/_sections/pairprogramming-vscode.md){:class="uk-button uk-button-success"}
+[Suggest an Edit to this Page](https://github.com/GitLiveApp/GitLive/edit/master/_sections/pairprogramming-vscode.md){:class="uk-button uk-button-success"}
 

--- a/_sections/privacy-android-studio.md
+++ b/_sections/privacy-android-studio.md
@@ -95,4 +95,4 @@ On the left, GitLive shows that  **SuDa2103** has made some changes to the **Sam
 
 
 
-[Suggest an Edit to this Page](https://github.com/GitLiveApp/documentation/edit/master/_sections/privacy-android-studio.md){:class="uk-button uk-button-success"}
+[Suggest an Edit to this Page](https://github.com/GitLiveApp/GitLive/edit/master/_sections/privacy-android-studio.md){:class="uk-button uk-button-success"}

--- a/_sections/privacy-jetbrains.md
+++ b/_sections/privacy-jetbrains.md
@@ -95,4 +95,4 @@ On the left, GitLive shows that  **SuDa2103** has made some changes to the **Sam
 
 
 
-[Suggest an Edit to this Page](https://github.com/GitLiveApp/documentation/edit/master/_sections/privacy-jetbrains.md){:class="uk-button uk-button-success"}
+[Suggest an Edit to this Page](https://github.com/GitLiveApp/GitLive/edit/master/_sections/privacy-jetbrains.md){:class="uk-button uk-button-success"}

--- a/_sections/privacy-vscode.md
+++ b/_sections/privacy-vscode.md
@@ -95,4 +95,4 @@ On the left, GitLive shows that  **teamhubuser** has made some changes to the **
 </table>
 
 
-[Suggest an Edit to this Page](https://github.com/GitLiveApp/documentation/edit/master/_sections/privacy-vscode.md){:class="uk-button uk-button-success"}
+[Suggest an Edit to this Page](https://github.com/GitLiveApp/GitLive/edit/master/_sections/privacy-vscode.md){:class="uk-button uk-button-success"}

--- a/_sections/teammember-android-studio.md
+++ b/_sections/teammember-android-studio.md
@@ -29,4 +29,4 @@ In this quick guide you will learn how to authenticate GitLive on Android Studio
 ![Confirm installation](/uploads/android-studio-installed.jpeg  "Confirm installation"){:class="screenshot"}
 
 
-[Suggest an Edit to this Page](https://github.com/GitLiveApp/documentation/edit/master/_sections/teammember-android-studio.md){:class="uk-button uk-button-success"}
+[Suggest an Edit to this Page](https://github.com/GitLiveApp/GitLive/edit/master/_sections/teammember-android-studio.md){:class="uk-button uk-button-success"}

--- a/_sections/teammember-android-studio.md
+++ b/_sections/teammember-android-studio.md
@@ -13,7 +13,7 @@ In this quick guide you will learn how to authenticate GitLive on Android Studio
 
 ### Step 1
 
-* Install the plugin as explained in the [installation section](/docs/installation){:class="internal-link"}
+* Install the plugin as explained in the [installation section](/){:class="internal-link"}
 * Open up a clone of the repository that you want to use GitLive with.
 
 ### Step 2

--- a/_sections/teammember-jetbrains.md
+++ b/_sections/teammember-jetbrains.md
@@ -13,7 +13,7 @@ In this quick guide you will learn how to authenticate GitLive on any JetBrains 
 
 ### Step 1
 
-* Install the plugin as explained in the [installation section](/docs/installation){:class="internal-link"}
+* Install the plugin as explained in the [installation section](/){:class="internal-link"}
 * Open up a clone of the repository that you want to use GitLive with.
 
 ### Step 2

--- a/_sections/teammember-jetbrains.md
+++ b/_sections/teammember-jetbrains.md
@@ -29,4 +29,4 @@ In this quick guide you will learn how to authenticate GitLive on any JetBrains 
 ![Confirm installation](/uploads/jetbrains-installed-2.jpg  "Confirm installation"){:class="screenshot"}
 
 
-[Suggest an Edit to this Page](https://github.com/GitLiveApp/documentation/edit/master/_sections/teammember-jetbrains.md){:class="uk-button uk-button-success"}
+[Suggest an Edit to this Page](https://github.com/GitLiveApp/GitLive/edit/master/_sections/teammember-jetbrains.md){:class="uk-button uk-button-success"}

--- a/_sections/teammember-vscode.md
+++ b/_sections/teammember-vscode.md
@@ -12,7 +12,7 @@ In this quick guide you will learn how to authenticate GitLive in VS Code as a t
 
 ### Step 1
 
-* Install the plugin as explained in the [installation section](/docs/installation){:class="internal-link"}.
+* Install the plugin as explained in the [installation section](/){:class="internal-link"}.
 * Open up a clone of your the repository that you want to use GitLive with.
 
 ### Step 2

--- a/_sections/teammember-vscode.md
+++ b/_sections/teammember-vscode.md
@@ -28,4 +28,4 @@ In this quick guide you will learn how to authenticate GitLive in VS Code as a t
 ![Confirm installation](/uploads/vscode-installed.jpg  "Confirm installation"){:class="screenshot"}
 
 
-[Suggest an Edit to this Page](https://github.com/GitLiveApp/documentation/edit/master/_sections/teammember-vscode.md){:class="uk-button uk-button-success"}
+[Suggest an Edit to this Page](https://github.com/GitLiveApp/GitLive/edit/master/_sections/teammember-vscode.md){:class="uk-button uk-button-success"}

--- a/_sections/visibility-android-studio.md
+++ b/_sections/visibility-android-studio.md
@@ -86,7 +86,7 @@ The aim of the activity graph is to give a team with flexible working hours or r
 ![See how active others have been in the last 24 hrs](/uploads/android-studio-visibility-activity.jpeg "Activity Visibility"){:class="screenshot"}
 
 
-[Suggest an Edit to this Page](https://github.com/GitLiveApp/documentation/edit/master/_sections/visibility-android-studio.md){:class="uk-button uk-button-success"}
+[Suggest an Edit to this Page](https://github.com/GitLiveApp/GitLive/edit/master/_sections/visibility-android-studio.md){:class="uk-button uk-button-success"}
 
 
 

--- a/_sections/visibility-jetbrains.md
+++ b/_sections/visibility-jetbrains.md
@@ -86,4 +86,4 @@ The aim of the activity graph is to give a team with flexible working hours or r
 ![See how active others have been in the last 24 hrs](/uploads/visibility-activity.jpg "Activity Visibility"){:class="screenshot"}
 
 
-[Suggest an Edit to this Page](https://github.com/GitLiveApp/documentation/edit/master/_sections/visibility-jetbrains.md){:class="uk-button uk-button-success"}
+[Suggest an Edit to this Page](https://github.com/GitLiveApp/GitLive/edit/master/_sections/visibility-jetbrains.md){:class="uk-button uk-button-success"}

--- a/_sections/visibility-vscode.md
+++ b/_sections/visibility-vscode.md
@@ -75,5 +75,5 @@ You can also use GitLive to see which particular lines are different in your tea
 ![See the changes in their working copy](/uploads/vscode-diff-view.gif "Diff View"){:class="screenshot"}
 
 
-[Suggest an Edit to this Page](https://github.com/GitLiveApp/documentation/edit/master/_sections/visibility-vscode.md){:class="uk-button uk-button-success"}
+[Suggest an Edit to this Page](https://github.com/GitLiveApp/GitLive/edit/master/_sections/visibility-vscode.md){:class="uk-button uk-button-success"}
 


### PR DESCRIPTION
Redirect set up using jekyll-redirect-from gem so that root path is now the installation page, and the installation page is included in the Navbar as normal