### PR TITLE
Windows installation

### DIFF
--- a/_sections/installation-android-studio.md
+++ b/_sections/installation-android-studio.md
@@ -16,7 +16,7 @@ Mac:
 * In the _Preferences_ dialog, click on _Plugins_.
 
 Windows/Linux:
-* Launch _Android Studio_ and click on _Settings_ under the  _file_ option.
+* Launch _Android Studio_ and click on _Settings_ under the  _file_ menu.
 * In the _Settings_ dialog, click on _Plugins_.
 
 ![Click on Preferences then Plugins](/uploads/android-studio-plugin.jpeg){:class="screenshot"}

--- a/_sections/installation-android-studio.md
+++ b/_sections/installation-android-studio.md
@@ -10,9 +10,14 @@ In this quick guide you will learn how to install GitLive into the Android Studi
 ### Step 1
 ### Open the Plugins Dialog
 
+Mac:
 * Launch _Android Studio_ and click on the Android Studio _menu_ option.
 * Select _Preferences_.
 * In the _Preferences_ dialog, click on _Plugins_.
+
+Windows/Linux:
+* Launch _Android Studio_ and click on _Settings_ under the  _file_ option.
+* In the _Settings_ dialog, click on _Plugins_.
 
 ![Click on Preferences then Plugins](/uploads/android-studio-plugin.jpeg){:class="screenshot"}
 

--- a/_sections/installation-jetbrain.md
+++ b/_sections/installation-jetbrain.md
@@ -16,7 +16,7 @@ Mac:
 * In the _Preferences_ dialog, click on _Plugins_.
 
 Windows/Linux:
-* Launch your IDE and click on _Settings_ under the  _file_ option.
+* Launch your IDE and click on _Settings_ under the _file_ menu.
 * In the _Settings_ dialog, click on _Plugins_.
 
 ![Click on Preferences then Plugins](/uploads/jetbrains-plugin-2.jpg "Plugins"){:class="screenshot"}

--- a/_sections/installation-jetbrain.md
+++ b/_sections/installation-jetbrain.md
@@ -10,9 +10,14 @@ In this quick guide you will learn how to install GitLive into any JetBrains IDE
 ### Step 1
 ### Open the Plugins Dialog
 
+For mac:
 * Launch your IDE and click on the IDE's name _menu_ option.
 * Select _Preferences_.
 * In the _Preferences_ dialog, click on _Plugins_.
+
+For windows or linux:
+* Launch your IDE and click on _Settings_ under the  _file_ option.
+* In the _Settings_ dialog, click on _Plugins_.
 
 ![Click on Preferences then Plugins](/uploads/jetbrains-plugin-2.jpg "Plugins"){:class="screenshot"}
 

--- a/_sections/installation-jetbrain.md
+++ b/_sections/installation-jetbrain.md
@@ -10,12 +10,12 @@ In this quick guide you will learn how to install GitLive into any JetBrains IDE
 ### Step 1
 ### Open the Plugins Dialog
 
-For mac:
+Mac:
 * Launch your IDE and click on the IDE's name _menu_ option.
 * Select _Preferences_.
 * In the _Preferences_ dialog, click on _Plugins_.
 
-For windows or linux:
+Windows/Linux:
 * Launch your IDE and click on _Settings_ under the  _file_ option.
 * In the _Settings_ dialog, click on _Plugins_.
 


### PR DESCRIPTION
Installation instructions for Jetbrains and Android Studio now split out into Mac and Windows instructions for step 1